### PR TITLE
math.h is case-sensitive on unix, changing Math.h to math.h.

### DIFF
--- a/Adafruit_9DOF.cpp
+++ b/Adafruit_9DOF.cpp
@@ -21,7 +21,7 @@
 
 #include <Wire.h>
 #include <limits.h>
-#include <Math.h>
+#include <math.h>
 
 #include "Adafruit_9DOF.h"
 


### PR DESCRIPTION
I'm assuming you must be building  / testing on another platform.. maybe Windows where filenames are not case-sensitive?  Or is there a reason you're using capitalized Math.h?

Thanks,
- J.
