### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Designed specifically to work with the Adafruit 9DOF Breakout, and is 
 category=Sensors
 url=https://github.com/adafruit/Adafruit_9DOF
 architectures=*
+depends=Adafruit Unified Sensor, Adafruit LSM303DLHC, Adafruit L3GD20 U


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format